### PR TITLE
Make sure direction is written before value.

### DIFF
--- a/sht21httpd.cc
+++ b/sht21httpd.cc
@@ -88,6 +88,7 @@ void read_sht21(std::atomic_uchar &run){
   for(uint32_t i=0; i<gpio.size(); i++){
     std::ofstream of_dir(gpio_str+std::to_string(gpio[i])+"/direction");
     of_dir << "out";
+    of_dir.close();
     std::this_thread::sleep_for (std::chrono::seconds(1));
     std::ofstream of_val(gpio_str+std::to_string(gpio[i])+"/value");
     if(i == 0)


### PR DESCRIPTION
Due to buffering within ofstream, the actual write order to the direction and value pseudo-files might be different from what's expected.
(And actually in my case, strace says it's the other way round.)